### PR TITLE
Add build class

### DIFF
--- a/lib/riot_set_builder/build.rb
+++ b/lib/riot_set_builder/build.rb
@@ -1,0 +1,43 @@
+module RiotSetBuilder
+  class Build
+    attr_accessor :title, :type, :map, :mode, :priority, :sortrank, :blocks
+
+    DEFAULT_OPTIONS = {
+      type: "global",
+      map: "SR",
+      mode: "any",
+      priority: false,
+      sortrank: 0,
+      blocks: []
+    }
+
+    VALID_OPTIONS = {
+      types: [ "global", "custom" ],
+      maps: [ "any", "SR", "HA", "TT", "CS" ],
+      modes: [ "any", "CLASSIC", "ARAM", "ODIN" ]
+    }
+
+    def initialize(options = {})
+      options = DEFAULT_OPTIONS.merge(options)
+
+      @title = options[:title]
+      @type = options[:type]
+      @map = options[:map]
+      @mode = options[:mode]
+      @priority = options[:priority]
+      @sortrank = options[:sortrank]
+      @blocks = options[:blocks]
+
+      verify_attributes
+    end
+
+    private
+
+    def verify_attributes
+      raise "Title required for build" unless title
+      raise "Invalid type, valid types are #{ VALID_OPTIONS.types }" unless VALID_OPTIONS[:types].include?(type)
+      raise "Invalid map, valid maps are #{ VALID_OPTIONS.maps }" unless VALID_OPTIONS[:maps].include?(map)
+      raise "invalid mode, valid modes are #{ VALID_OPTIONS.modes }" unless VALID_OPTIONS[:modes].include?(mode)
+    end
+  end
+end

--- a/spec/riot_set_builder/build_spec.rb
+++ b/spec/riot_set_builder/build_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'riot_set_builder/build'
+
+RSpec.describe RiotSetBuilder::Build do
+  describe "#initialize" do
+    subject { described_class.new(test_options) }
+
+    context "when valid options are passed" do
+
+      context "when all options are passed" do
+        let(:test_options) do
+          {
+            title: "PB - Dyrus",
+            type: "custom",
+            map: "TT",
+            mode: "CLASSIC",
+            priority: true,
+            sortrank: 1,
+            blocks: []
+          }
+        end
+
+        it "assigns the correct values" do
+          expect(subject).to have_attributes test_options
+        end
+      end
+
+      context "when only required options are passed" do
+        let(:test_options) { { title: "PB - Dyrus" } }
+
+        it "assigns default values" do
+          expect(subject).to have_attributes(type: "global", map: "SR", mode: "any", priority: false, sortrank: 0, blocks: [])
+        end
+      end
+    end
+
+    context "when invalid options are passed" do
+
+      shared_examples "an invalid build" do
+        it "raises an error" do
+          expect{ subject }.to raise_error
+        end
+      end
+
+      context "when no title is passed" do
+        let(:test_options) { {} }
+
+        it_behaves_like "an invalid build"
+      end
+
+      context "when an invalid type is passed" do
+        let(:test_options) { { name: "PB - Dyrus", type: "RitoPlz" } }
+
+        it_behaves_like "an invalid build"
+      end
+
+      context "when an invalid map is passed" do
+        let(:test_options) { { name: "PB - Dyrus", map: "KK" } }
+
+        it_behaves_like "an invalid build"
+      end
+
+      context "when an invalid mode is passed" do
+        let(:test_options) { { name: "PB - Dyrus", mode: "Sandbox" } }
+
+        it_behaves_like "an invalid build"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a build class which holds all the information for a riot item build.
It verifies valid options are passed according to riot API.
