### PR TITLE
Add vendor to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/


### PR DESCRIPTION
The vendor folder is where bundle install should install your gems and
other utilities, there's no need to commit this.
