### PR TITLE
Make project consistent with errors

### DIFF
--- a/lib/riot_set_builder/build.rb
+++ b/lib/riot_set_builder/build.rb
@@ -1,5 +1,9 @@
+require 'riot_set_builder/errors'
+
 module RiotSetBuilder
   class Build
+    include Error::Build
+
     attr_accessor :title, :type, :map, :mode, :priority, :sortrank, :blocks
 
     DEFAULT_OPTIONS = {
@@ -34,10 +38,10 @@ module RiotSetBuilder
     private
 
     def verify_attributes
-      raise "Title required for build" unless title
-      raise "Invalid type, valid types are #{ VALID_OPTIONS.types }" unless VALID_OPTIONS[:types].include?(type)
-      raise "Invalid map, valid maps are #{ VALID_OPTIONS.maps }" unless VALID_OPTIONS[:maps].include?(map)
-      raise "invalid mode, valid modes are #{ VALID_OPTIONS.modes }" unless VALID_OPTIONS[:modes].include?(mode)
+      raise NoTitle, "Title required for build" unless title
+      raise InvalidType, "Invalid type, valid types are #{ VALID_OPTIONS[:types] }" unless VALID_OPTIONS[:types].include?(type)
+      raise InvalidMap, "Invalid map, valid maps are #{ VALID_OPTIONS[:maps] }" unless VALID_OPTIONS[:maps].include?(map)
+      raise InvalidMode, "invalid mode, valid modes are #{ VALID_OPTIONS[:modes] }" unless VALID_OPTIONS[:modes].include?(mode)
     end
   end
 end

--- a/lib/riot_set_builder/build.rb
+++ b/lib/riot_set_builder/build.rb
@@ -1,4 +1,5 @@
 require 'riot_set_builder/errors'
+require 'riot_set_builder/item'
 
 module RiotSetBuilder
   class Build

--- a/lib/riot_set_builder/item.rb
+++ b/lib/riot_set_builder/item.rb
@@ -1,5 +1,9 @@
+require 'riot_set_builder/errors'
+
 module RiotSetBuilder
   class Item
+    include Error::Item
+
     attr_accessor :id, :count
 
     DEFAULT_OPTIONS = {
@@ -16,8 +20,8 @@ module RiotSetBuilder
     end
 
     def verify_attributes
-      raise "Item requires an ID" unless id
-      raise "Item's count must be a number >= 0"  unless count >= 0
+      raise NoID, "Item requires an ID" unless id
+      raise InvalidCount, "Item's count must be a number >= 0"  unless count >= 0
     end
   end
 end

--- a/spec/riot_set_builder/build_spec.rb
+++ b/spec/riot_set_builder/build_spec.rb
@@ -36,34 +36,34 @@ RSpec.describe RiotSetBuilder::Build do
 
     context "when invalid options are passed" do
 
-      shared_examples "an invalid build" do
+      shared_examples "a method that raises an error" do |error_class|
         it "raises an error" do
-          expect{ subject }.to raise_error
+          expect{ subject }.to raise_error error_class
         end
       end
 
       context "when no title is passed" do
         let(:test_options) { {} }
 
-        it_behaves_like "an invalid build"
+        it_behaves_like "a method that raises an error", described_class::NoTitle
       end
 
       context "when an invalid type is passed" do
-        let(:test_options) { { name: "PB - Dyrus", type: "RitoPlz" } }
+        let(:test_options) { { title: "PB - Dyrus", type: "RitoPlz" } }
 
-        it_behaves_like "an invalid build"
+        it_behaves_like "a method that raises an error", described_class::InvalidType
       end
 
       context "when an invalid map is passed" do
-        let(:test_options) { { name: "PB - Dyrus", map: "KK" } }
+        let(:test_options) { { title: "PB - Dyrus", map: "KK" } }
 
-        it_behaves_like "an invalid build"
+        it_behaves_like "a method that raises an error", described_class::InvalidMap
       end
 
       context "when an invalid mode is passed" do
-        let(:test_options) { { name: "PB - Dyrus", mode: "Sandbox" } }
+        let(:test_options) { { title: "PB - Dyrus", mode: "Sandbox" } }
 
-        it_behaves_like "an invalid build"
+        it_behaves_like "a method that raises an error", described_class::InvalidMode
       end
     end
   end

--- a/spec/riot_set_builder/item_spec.rb
+++ b/spec/riot_set_builder/item_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe RiotSetBuilder::Item do
+  describe "#initialize" do
+    subject { described_class.new(test_options) }
+
+    context "when valid options are passed" do
+
+      context "when all options are passed" do
+        let(:test_options) do
+          {
+            id: 1234,
+            count: 3
+          }
+        end
+
+        it "assigns the correct values" do
+          expect(subject).to have_attributes(id: 1234, count: 3)
+        end
+      end
+
+      context "when only required options are passed" do
+        let(:test_options) do
+          {
+            id: 1234
+          }
+        end
+
+        it "assigns default values" do
+          expect(subject).to have_attributes(id:1234, count: 1)
+        end
+      end
+    end
+
+    context "when invalid options are passed" do
+
+      shared_examples "a method that raises an error" do |error_class|
+        it "raises an error" do
+          expect { subject }.to raise_error error_class
+        end
+      end
+
+      context "when no id is passed" do
+        let(:test_options) { {} }
+
+        it_behaves_like "a method that raises an error", described_class::NoID
+      end
+
+      context "when an invalid item count is passed" do
+        let(:test_options) do
+          {
+            id: 1234,
+            count: -1
+          }
+        end
+
+        it_behaves_like "a method that raises an error", described_class::InvalidCount
+      end
+    end
+  end
+end


### PR DESCRIPTION
Now that we've added errors, this PR is to make our old models that didn't use our custom errors, to take advantage of them. This includes changing specs, and even finding some bugs that we missed with our old specs. This also adds specs for items.
